### PR TITLE
adapt to unix-style path separator

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,12 +44,12 @@ pub struct InitTheme {
 pub fn init() -> Result<InitConfig, ExitFailure> {
     match dirs::home_dir() {
         Some(home_path) => {
-            let config_path = format!(
-                "{}\\.config\\music_player\\config.yml",
-                home_path.to_str().unwrap()
-            );
-
-            let file = std::fs::File::open(config_path)?;
+            let mut pathbuf = std::path::PathBuf::new();
+            pathbuf.push(home_path.to_str().unwrap());
+            pathbuf.push(".config");
+            pathbuf.push("music_player");
+            pathbuf.push("config.yml");
+            let file = std::fs::File::open(pathbuf)?;
             let init_config: InitConfig = serde_yaml::from_reader(file)?;
 
             Ok(init_config)

--- a/src/utils/split_path.rs
+++ b/src/utils/split_path.rs
@@ -1,4 +1,4 @@
 pub fn split_path_to_name(path: &str) -> &str {
-    let str = path.split("\\").collect::<Vec<&str>>();
-    str.last().unwrap()
+    let p = std::path::Path::new(path);
+    p.file_name().unwrap().to_str().unwrap()
 }


### PR DESCRIPTION
Adapt to unix-style path separator so that this program could runs on Linux and macOS

> Only tested on macOS and it works well.
> Tests on Linux are needed.